### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/moonrelay/cli/proxy_command.rb
+++ b/lib/moonrelay/cli/proxy_command.rb
@@ -66,7 +66,7 @@ module Moonrelay
               puts ""
               puts "----"
               p ["->", m.encoding, m]
-              if m.encoding.name == "ASCII-8BIT"
+              if m.encoding == Encoding::BINARY
                 ws.send m.unpack("C*")
               else
                 ws.send m


### PR DESCRIPTION
Comparing the names is much less efficient than comparing the instance directly.
    
It may also change in the future: https://bugs.ruby-lang.org/issues/18576